### PR TITLE
Disable OMP Tools Interface when using HPXC

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -113,7 +113,7 @@ endif()
 
 set(ENABLE_OMPT_TOOLS ON)
 # Currently tools are not tested well on Windows or MacOS X.
-if (APPLE OR WIN32)
+if (APPLE OR WIN32 OR WITH_HPXC)
   set(ENABLE_OMPT_TOOLS OFF)
 endif()
 

--- a/openmp/runtime/CMakeLists.txt
+++ b/openmp/runtime/CMakeLists.txt
@@ -313,7 +313,7 @@ endif()
 # OMPT-support defaults to ON for OpenMP 5.0+ and if the requirements in
 # cmake/config-ix.cmake are fulfilled.
 set(OMPT_DEFAULT FALSE)
-if ((LIBOMP_HAVE_OMPT_SUPPORT) AND (NOT WIN32))
+if ((LIBOMP_HAVE_OMPT_SUPPORT) AND (NOT WIN32) AND (NOT WITH_HPXC))
   set(OMPT_DEFAULT TRUE)
 endif()
 set(LIBOMP_OMPT_SUPPORT ${OMPT_DEFAULT} CACHE BOOL


### PR DESCRIPTION
Some OMP Tools (such as Archer thread sanitizer which is included in LLVM) assume that linux implementations use pthreads for threading, which doesn't work well with HPXC.
This PR fixes that issue by disabling OMPT by default when using HPXC.

Fixes segfault mentioned in issue #3 
Makes HPXMP work smoothly (afaics), along with PR #5 