### PR TITLE
Prevent OMP using thread local storage for storing gtid

### DIFF
--- a/openmp/runtime/src/kmp_config.h.cmake
+++ b/openmp/runtime/src/kmp_config.h.cmake
@@ -119,7 +119,7 @@
 #if ! KMP_MIC
 # define USE_LOAD_BALANCE 1
 #endif
-#if ! (KMP_OS_WINDOWS || KMP_OS_DARWIN)
+#if ! (KMP_OS_WINDOWS || KMP_OS_DARWIN || HPXC)
 # define KMP_TDATA_GTID 1
 #endif
 #if STUBS_LIBRARY

--- a/openmp/runtime/src/kmp_global.cpp
+++ b/openmp/runtime/src/kmp_global.cpp
@@ -173,7 +173,7 @@ int __kmp_abort_delay = 0;
 #if KMP_OS_LINUX && defined(KMP_TDATA_GTID)
 int __kmp_gtid_mode = 3; /* use __declspec(thread) TLS to store gtid */
 int __kmp_adjust_gtid_mode = FALSE;
-#elif KMP_OS_WINDOWS
+#elif KMP_OS_WINDOWS || defined(HPXC)
 int __kmp_gtid_mode = 2; /* use TLS functions to store gtid */
 int __kmp_adjust_gtid_mode = FALSE;
 #else


### PR DESCRIPTION
Duplicate of https://github.com/STEllAR-GROUP/llvm-project/pull/5, which was closed accidentally.