### PR TITLE
Re-enable OMPT, disable Archer

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -118,7 +118,7 @@ endif()
 
 set(ENABLE_OMPT_TOOLS ON)
 # Currently tools are not tested well on Windows or MacOS X.
-if (APPLE OR WIN32 OR WITH_HPXC)
+if (APPLE OR WIN32)
   set(ENABLE_OMPT_TOOLS OFF)
 endif()
 

--- a/openmp/runtime/CMakeLists.txt
+++ b/openmp/runtime/CMakeLists.txt
@@ -313,7 +313,7 @@ endif()
 # OMPT-support defaults to ON for OpenMP 5.0+ and if the requirements in
 # cmake/config-ix.cmake are fulfilled.
 set(OMPT_DEFAULT FALSE)
-if ((LIBOMP_HAVE_OMPT_SUPPORT) AND (NOT WIN32) AND (NOT WITH_HPXC))
+if ((LIBOMP_HAVE_OMPT_SUPPORT) AND (NOT WIN32))
   set(OMPT_DEFAULT TRUE)
 endif()
 set(LIBOMP_OMPT_SUPPORT ${OMPT_DEFAULT} CACHE BOOL

--- a/openmp/runtime/src/ompt-general.cpp
+++ b/openmp/runtime/src/ompt-general.cpp
@@ -355,7 +355,7 @@ ompt_try_start_tool(unsigned int omp_version, const char *runtime_version) {
     return ret;
   }
 
-#if KMP_OS_UNIX
+#if KMP_OS_UNIX && !HPXC
   { // Non-standard: load archer tool if application is built with TSan
     const char *fname = "libarcher.so";
     OMPT_VERBOSE_INIT_PRINT(

--- a/openmp/tools/archer/CMakeLists.txt
+++ b/openmp/tools/archer/CMakeLists.txt
@@ -8,7 +8,7 @@
   
   
 
-if(LIBOMP_OMPT_SUPPORT)
+if(LIBOMP_OMPT_SUPPORT AND (NOT WITH_HPXC))
   include_directories(${LIBOMP_INCLUDE_DIR})
 
   add_library(archer SHARED ompt-tsan.cpp)


### PR DESCRIPTION
Re-enable OMPT (which was disabled by https://github.com/STEllAR-GROUP/llvm-project/pull/4). Archer address sanitizer, which caused a problem originally, is now being disabled.
